### PR TITLE
Update model name in Main_queries.xml

### DIFF
--- a/output/queries/Main_queries.xml
+++ b/output/queries/Main_queries.xml
@@ -4238,7 +4238,7 @@ local:generate-sector-output-coefs(remove($inputNameQueue, 1), $currTree, $coefs
             <comments/>
         </costCurveQuery>
     </queryGroup>
-    <queryGroup name="water demands (not valid for GCAM-USA)">
+    <queryGroup name="water demands (not valid for GCAM-China)">
         <supplyDemandQuery title="water withdrawals by region">
             <axis1 name="region">region</axis1>
             <axis2 name="Year">demand-physical[@vintage]</axis2>


### PR DESCRIPTION
The original code used "water demands (not valid for GCAM-USA)," which could easily confuse users. To improve clarity, I changed this to "GCAM-China" for better alignment with the model.

Additionally, I recommend removing the entire water demands section from Main_queries.xml, as it is not applicable to region-specific versions of GCAM.